### PR TITLE
Remove obsolete setTimeout inside moveLog

### DIFF
--- a/ccu.io.js
+++ b/ccu.io.js
@@ -2502,7 +2502,6 @@ function writeLog() {
 
 function moveLog(file) {
     logMoving[file] = true;
-    setTimeout(moveLog, 86400000);
     var ts = (new Date()).getTime() - 3600000;
     ts = new Date(ts);
 


### PR DESCRIPTION
This produced multiple "moving Logfile undefined " lines in ccu.io.log
